### PR TITLE
fix formatting

### DIFF
--- a/twitter/functions/twitter_ingest_primary_get_tweets/utilities.py
+++ b/twitter/functions/twitter_ingest_primary_get_tweets/utilities.py
@@ -90,7 +90,7 @@ def parse_tweets(tweet):
         tweets.append(format_naked_tweet(main["retweet"]["id"]))
         users.append(format_naked_user(main["retweet"]["user_id"]))
         main["obj"]["text"] = tweet.retweeted_status.full_text
-        retweets.append(format_naked_relationship({
+        retweets = format_naked_relationship({
             "source": {
                 "user": tweet.user._json
                 },
@@ -99,7 +99,11 @@ def parse_tweets(tweet):
                 "obj": main["obj"]
                 },
             "in_graph": False
-        }))
+        })
+        retweet['source']['user']['created_at'] = tweet.user.created_at
+        retweet['target']['user']['created_at'] = tweet.retweeted_status.user.created_at
+        retweet['target']['obj']['entities'] = tweet.entities
+        retweets.append(retweet)
     # process quote
     try:
         main["quote"] = {


### PR DESCRIPTION
Twitter seems to send dates in a very weird format that elasticsearch can't parse by default. So I need to pull the dates out of the User object (which contains data that is parsed by tweepy) instead of the raw data returned by Twitter, so that it can be sent in a format that elasticsearch can parse into a date.

I'm less clear on why i need to change target.obj.entities, but it does make sense to send the entities object instead of the json string of the object (see line 51, "entities": json.dumps(tweet.entities)).  